### PR TITLE
crypto: discover hashes from OpenSSL providers

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -6484,6 +6484,14 @@ bool EVPMDCtxPointer::digestInit(const Digest& digest) {
   return EVP_DigestInit_ex(ctx_.get(), digest, nullptr) > 0;
 }
 
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_PREREQ(4, 0)
+bool EVPMDCtxPointer::digestInit(const Digest& digest,
+                                 const OSSL_PARAM* params) {
+  if (!ctx_) return false;
+  return EVP_DigestInit_ex2(ctx_.get(), digest, params) > 0;
+}
+#endif
+
 bool EVPMDCtxPointer::digestUpdate(const Buffer<const void>& in) {
   if (!ctx_) return false;
   return EVP_DigestUpdate(ctx_.get(), in.data, in.len) > 0;
@@ -7145,14 +7153,82 @@ size_t Digest::size() const {
   return EVP_MD_size(md_);
 }
 
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+Digest::Digest(DeleteFnPtr<EVP_MD, EVP_MD_free> md)
+    : md_(md.get()), fetched_md_(std::move(md)) {}
+#endif
+
+Digest::Digest(const Digest& other) : md_(other.md_) {
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+  if (other.fetched_md_ != nullptr) {
+    if (EVP_MD_up_ref(other.fetched_md_.get()) == 1) {
+      fetched_md_.reset(other.fetched_md_.get());
+    } else {
+      md_ = nullptr;
+    }
+  }
+#endif
+}
+
+Digest& Digest::operator=(const Digest& other) {
+  if (this == &other) return *this;
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+  if (other.fetched_md_ != nullptr) {
+    if (EVP_MD_up_ref(other.fetched_md_.get()) == 1) {
+      fetched_md_.reset(other.fetched_md_.get());
+    } else {
+      fetched_md_.reset();
+      md_ = nullptr;
+      return *this;
+    }
+  } else {
+    fetched_md_.reset();
+  }
+#endif
+  md_ = other.md_;
+  return *this;
+}
+
 const Digest Digest::MD5 = Digest(EVP_md5());
 const Digest Digest::SHA1 = Digest(EVP_sha1());
 const Digest Digest::SHA256 = Digest(EVP_sha256());
 const Digest Digest::SHA384 = Digest(EVP_sha384());
 const Digest Digest::SHA512 = Digest(EVP_sha512());
 
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+namespace {
+bool IsSupportedDigest(const EVP_MD* md) {
+  if (md == nullptr || EVP_MD_is_a(md, "NULL")) return false;
+
+  // OpenSSL currently crashes when ML-DSA-MU finalizes an empty input. Keep it
+  // unavailable until the provider implementation is fixed.
+  // https://github.com/openssl/openssl/issues/32445
+  if (EVP_MD_is_a(md, "ML-DSA-MU")) return false;
+
+  return true;
+}
+}  // namespace
+#endif
+
 const Digest Digest::FromName(const char* name) {
-  return ncrypto::getDigestByName(name);
+  const EVP_MD* md = ncrypto::getDigestByName(name);
+  if (md != nullptr) {
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+    if (!IsSupportedDigest(md)) return Digest();
+#endif
+    return Digest(md);
+  }
+
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+  MarkPopErrorOnReturn mark_pop_error_on_return;
+  DeleteFnPtr<EVP_MD, EVP_MD_free> fetched(
+      EVP_MD_fetch(nullptr, name, nullptr));
+  if (IsSupportedDigest(fetched.get())) {
+    return Digest(std::move(fetched));
+  }
+#endif
+
+  return Digest();
 }
 
 // ============================================================================

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -397,9 +397,12 @@ class Digest final {
   static constexpr size_t MAX_SIZE = EVP_MAX_MD_SIZE;
   Digest() = default;
   Digest(const EVP_MD* md) : md_(md) {}
-  Digest(const Digest&) = default;
-  Digest& operator=(const Digest&) = default;
+  Digest(const Digest& other);
+  Digest& operator=(const Digest& other);
   inline Digest& operator=(const EVP_MD* md) {
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+    fetched_md_.reset();
+#endif
     md_ = md;
     return *this;
   }
@@ -421,6 +424,10 @@ class Digest final {
 
  private:
   const EVP_MD* md_ = nullptr;
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+  explicit Digest(DeleteFnPtr<EVP_MD, EVP_MD_free> md);
+  DeleteFnPtr<EVP_MD, EVP_MD_free> fetched_md_;
+#endif
 };
 
 // Computes a fixed-length digest.
@@ -1691,6 +1698,9 @@ class EVPMDCtxPointer final {
   EVP_MD_CTX* release();
 
   bool digestInit(const Digest& digest);
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_PREREQ(4, 0)
+  bool digestInit(const Digest& digest, const OSSL_PARAM* params);
+#endif
   bool digestUpdate(const Buffer<const void>& in);
   DataPointer digestFinal(size_t length);
   bool digestFinalInto(Buffer<void>* buf);

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3808,6 +3808,11 @@ and description of each available elliptic curve.
 added: v0.1.92
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Hash algorithms exposed by OpenSSL providers are now
+                 supported. The `functionName` and `customization` options
+                 were added for cSHAKE hash functions.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/64000
     description: The `outputLength` option is now required for XOF
                  hash functions without default output lengths.
@@ -3818,6 +3823,14 @@ changes:
 
 * `algorithm` {string}
 * `options` {Object} [`stream.transform` options][]
+  * `customization` {string|ArrayBuffer|Buffer|TypedArray|DataView} For cSHAKE
+    hash functions, specifies the customization byte string. **Default:** an
+    empty byte string.
+  * `functionName` {string|ArrayBuffer|Buffer|TypedArray|DataView} For cSHAKE
+    hash functions, specifies the NIST function-name byte string. **Default:**
+    an empty byte string.
+  * `outputLength` {number} For XOF hash functions, specifies the desired
+    output length in bytes.
 * Returns: {Hash}
 
 Creates and returns a `Hash` object that can be used to generate hash digests
@@ -3826,12 +3839,23 @@ behavior. For XOF hash functions such as `'shake256'`, the `outputLength` option
 specifies the desired output length in bytes. It is required for XOF hash
 functions without a default output length.
 
+The `functionName` and `customization` options apply only to cSHAKE-128 and
+cSHAKE-256. They are supported only when Node.js is built with OpenSSL 4.0 or
+later and the selected provider supports the corresponding digest parameters.
+Strings are encoded as UTF-8, and neither strings nor byte values may contain
+NUL bytes. Both options default to an empty byte string. For OpenSSL's built-in
+providers, `functionName` is case-sensitive and must be `''`, `'TupleHash'`,
+`'ParallelHash'`, or `'KMAC'`. Other providers can impose different
+restrictions. With both options empty, cSHAKE produces the same output as the
+corresponding SHAKE function for the same output length. `cshake-128` and
+`cshake-256` default to output lengths of 32 and 64 bytes, respectively.
+
 When the data is small (< 5MB) and readily available, [`crypto.hash()`][] is usually faster.
 
-The `algorithm` is dependent on the available algorithms supported by the
-version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
-On recent releases of OpenSSL, `openssl list -digest-algorithms` will
-display the available digest algorithms.
+The available algorithms depend on the version and configuration of OpenSSL on
+the platform. Examples are `'sha256'` and `'sha512'`. Use
+[`crypto.getHashes()`][] to obtain the list of hash algorithms available to the
+Node.js process.
 
 Example: generating the sha256 sum of a file
 
@@ -3917,10 +3941,11 @@ changes:
 Creates and returns an `Hmac` object that uses the given `algorithm` and `key`.
 Optional `options` argument controls stream behavior.
 
-The `algorithm` is dependent on the available algorithms supported by the
-version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
-On recent releases of OpenSSL, `openssl list -digest-algorithms` will
-display the available digest algorithms.
+The available algorithms depend on the version and configuration of OpenSSL on
+the platform. Examples are `'sha256'` and `'sha512'`.
+[`crypto.getHashes()`][] lists algorithms available to the hashing APIs, but
+HMAC imposes additional restrictions, so not every listed algorithm is
+suitable.
 
 The `key` is the HMAC key used to generate the cryptographic HMAC hash. If it is
 a [`KeyObject`][], its type must be `secret`. If it is a string, please consider
@@ -4204,8 +4229,10 @@ added: v0.1.92
 * Returns: {Sign}
 
 Creates and returns a `Sign` object that uses the given `algorithm`. Use
-[`crypto.getHashes()`][] to obtain the names of the available digest algorithms.
-Optional `options` argument controls the `stream.Writable` behavior.
+[`crypto.getHashes()`][] to obtain the names available to the hashing APIs. The
+key type and signature scheme can impose additional restrictions on which
+digests can be used. Optional `options` argument controls the
+`stream.Writable` behavior.
 
 In some cases, a `Sign` instance can be created using the name of a signature
 algorithm, such as `'RSA-SHA256'`, instead of a digest algorithm. This will use
@@ -4224,8 +4251,9 @@ added: v0.1.92
 * Returns: {Verify}
 
 Creates and returns a `Verify` object that uses the given algorithm.
-Use [`crypto.getHashes()`][] to obtain an array of names of the available
-signing algorithms. Optional `options` argument controls the
+Use [`crypto.getHashes()`][] to obtain the names available to the hashing APIs.
+The key type and signature scheme can impose additional restrictions on which
+digests can be used. Optional `options` argument controls the
 `stream.Writable` behavior.
 
 In some cases, a `Verify` instance can be created using the name of a signature
@@ -4474,6 +4502,10 @@ changes:
 Generates a new asymmetric key pair of the given `type`. See the
 supported [asymmetric key types][].
 
+For RSA-PSS keys, [`crypto.getHashes()`][] lists algorithms available to the
+hashing APIs, but not every listed digest can be encoded in RSA-PSS parameters
+or is supported by the active RSA implementation.
+
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
 the respective part of the key is returned as a [`KeyObject`][].
@@ -4595,6 +4627,10 @@ changes:
 
 Generates a new asymmetric key pair of the given `type`. See the
 supported [asymmetric key types][].
+
+For RSA-PSS keys, [`crypto.getHashes()`][] lists algorithms available to the
+hashing APIs, but not every listed digest can be encoded in RSA-PSS parameters
+or is supported by the active RSA implementation.
 
 If a `publicKeyEncoding` or `privateKeyEncoding` was specified, this function
 behaves as if [`keyObject.export()`][] had been called on its result. Otherwise,
@@ -4954,10 +4990,26 @@ mode][].
 
 <!-- YAML
 added: v0.9.3
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Names and aliases exposed by loaded OpenSSL providers that
+                 match the default property query are now included.
 -->
 
 * Returns: {string\[]} An array of the names of the supported hash algorithms,
   such as `'RSA-SHA256'`. Hash algorithms are also called "digest" algorithms.
+
+This is the authoritative Node.js list of hash algorithms available to
+[`crypto.createHash()`][] and [`crypto.hash()`][] in the current process. With
+OpenSSL 3 or later, the list depends on the loaded providers and the default
+property query in effect when the list is first generated. Some listed
+algorithms can require API-specific options, such as `outputLength` for XOF
+hash functions.
+
+A listed hash algorithm is not necessarily supported by APIs that combine a
+digest with another cryptographic operation, such as HMAC, key derivation, or
+signing. Those operations can apply additional restrictions.
 
 ```mjs
 const {
@@ -4996,6 +5048,11 @@ added:
  - v20.12.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Hash algorithms exposed by OpenSSL providers are now
+                 supported. The `functionName` and `customization` options
+                 were added for cSHAKE hash functions.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/64000
     description: The `outputLength` option is now required for XOF
                  hash functions without default output lengths.
@@ -5016,6 +5073,12 @@ changes:
   into a `TypedArray` using either `TextEncoder` or `Buffer.from()` and passing
   the encoded `TypedArray` into this API instead.
 * `options` {Object|string}
+  * `customization` {string|ArrayBuffer|Buffer|TypedArray|DataView} For cSHAKE
+    hash functions, specifies the customization byte string. **Default:** an
+    empty byte string.
+  * `functionName` {string|ArrayBuffer|Buffer|TypedArray|DataView} For cSHAKE
+    hash functions, specifies the NIST function-name byte string. **Default:**
+    an empty byte string.
   * `outputEncoding` {string} [Encoding][encoding] used to encode the
     returned digest. **Default:** `'hex'`.
   * `outputLength` {number} For XOF hash functions such as 'shake256',
@@ -5028,10 +5091,21 @@ the object-based `crypto.createHash()` when hashing a smaller amount of data
 (<= 5MB) that's readily available. If the data can be big or if it is streamed,
 it's still recommended to use `crypto.createHash()` instead.
 
-The `algorithm` is dependent on the available algorithms supported by the
-version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
-On recent releases of OpenSSL, `openssl list -digest-algorithms` will
-display the available digest algorithms.
+The available algorithms depend on the version and configuration of OpenSSL on
+the platform. Examples are `'sha256'` and `'sha512'`. Use
+[`crypto.getHashes()`][] to obtain the list of hash algorithms available to the
+Node.js process.
+
+The `functionName` and `customization` options apply only to cSHAKE-128 and
+cSHAKE-256. They are supported only when Node.js is built with OpenSSL 4.0 or
+later and the selected provider supports the corresponding digest parameters.
+Strings are encoded as UTF-8, and neither strings nor byte values may contain
+NUL bytes. Both options default to an empty byte string. For OpenSSL's built-in
+providers, `functionName` is case-sensitive and must be `''`, `'TupleHash'`,
+`'ParallelHash'`, or `'KMAC'`. Other providers can impose different
+restrictions. With both options empty, cSHAKE produces the same output as the
+corresponding SHAKE function for the same output length. `cshake-128` and
+`cshake-256` default to output lengths of 32 and 64 bytes, respectively.
 
 If `options` is a string, then it specifies the `outputEncoding`.
 
@@ -5103,6 +5177,10 @@ changes:
 
 HKDF is a simple key derivation function defined in RFC 5869. The given `ikm`,
 `salt` and `info` are used with the `digest` to derive a key of `keylen` bytes.
+The available digest algorithms depend on the version and configuration of
+OpenSSL. HKDF uses HMAC internally. [`crypto.getHashes()`][] lists algorithms
+available to the hashing APIs, but not every listed algorithm is necessarily
+suitable for HMAC or HKDF.
 
 The supplied `callback` function is called with two arguments: `err` and
 `derivedKey`. If an error occurs while deriving the key, `err` will be set;
@@ -5162,6 +5240,10 @@ changes:
 Provides a synchronous HKDF key derivation function as defined in RFC 5869. The
 given `ikm`, `salt` and `info` are used with the `digest` to derive a key of
 `keylen` bytes.
+The available digest algorithms depend on the version and configuration of
+OpenSSL. HKDF uses HMAC internally. [`crypto.getHashes()`][] lists algorithms
+available to the hashing APIs, but not every listed algorithm is necessarily
+suitable for HMAC or HKDF.
 
 The successfully generated `derivedKey` will be returned as an {ArrayBuffer}.
 
@@ -5271,8 +5353,10 @@ pbkdf2('secret', 'salt', 100000, 64, 'sha512', (err, derivedKey) => {
 });
 ```
 
-An array of supported digest functions can be retrieved using
-[`crypto.getHashes()`][].
+The available digest algorithms depend on the version and configuration of
+OpenSSL. PBKDF2 uses HMAC internally. [`crypto.getHashes()`][] lists algorithms
+available to the hashing APIs, but not every listed algorithm is necessarily
+suitable for HMAC or PBKDF2.
 
 This API uses libuv's threadpool, which can have surprising and
 negative performance implications for some applications; see the
@@ -5344,8 +5428,10 @@ const key = pbkdf2Sync('secret', 'salt', 100000, 64, 'sha512');
 console.log(key.toString('hex'));  // '3745e48...08d59ae'
 ```
 
-An array of supported digest functions can be retrieved using
-[`crypto.getHashes()`][].
+The available digest algorithms depend on the version and configuration of
+OpenSSL. PBKDF2 uses HMAC internally. [`crypto.getHashes()`][] lists algorithms
+available to the hashing APIs, but not every listed algorithm is necessarily
+suitable for HMAC or PBKDF2.
 
 ### `crypto.privateDecrypt(privateKey, buffer)`
 
@@ -5403,6 +5489,10 @@ changes:
 
 Decrypts `buffer` with `privateKey`. `buffer` was previously encrypted using
 the corresponding public key, for example using [`crypto.publicEncrypt()`][].
+
+[`crypto.getHashes()`][] lists algorithms available to the hashing APIs, but
+the active RSA implementation can impose additional restrictions on digests
+used for OAEP or MGF1.
 
 If `privateKey` is not a [`KeyObject`][], this function behaves as if
 `privateKey` had been passed to [`crypto.createPrivateKey()`][]. If it is an
@@ -5560,6 +5650,10 @@ changes:
 Encrypts the content of `buffer` with `key` and returns a new
 [`Buffer`][] with encrypted content. The returned data can be decrypted using
 the corresponding private key, for example using [`crypto.privateDecrypt()`][].
+
+[`crypto.getHashes()`][] lists algorithms available to the hashing APIs, but
+the active RSA implementation can impose additional restrictions on digests
+used for OAEP or MGF1.
 
 If `key` is not a [`KeyObject`][], this function behaves as if
 `key` had been passed to [`crypto.createPublicKey()`][]. If it is an
@@ -6347,6 +6441,10 @@ dependent upon the key type.
 `algorithm` is required to be `null` or `undefined` for Ed25519, Ed448, and
 ML-DSA.
 
+[`crypto.getHashes()`][] lists algorithms available to the hashing APIs, but
+the key type and signature scheme determine whether a listed digest can be
+used for signing.
+
 If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPrivateKey()`][]. When `key` is a string, `ArrayBuffer`,
 [`Buffer`][], `TypedArray`, or `DataView`, it must contain PEM-encoded key
@@ -6488,6 +6586,10 @@ key type.
 
 `algorithm` is required to be `null` or `undefined` for Ed25519, Ed448, and
 ML-DSA.
+
+[`crypto.getHashes()`][] lists algorithms available to the hashing APIs, but
+the key type and signature scheme determine whether a listed digest can be
+used for verification.
 
 If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
 passed to [`crypto.createPublicKey()`][]. When `key` is a string, `ArrayBuffer`,

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -6,6 +6,7 @@ const {
   StringPrototypeToLowerCase,
   Symbol,
   TypedArrayPrototypeGetBuffer,
+  TypedArrayPrototypeIncludes,
 } = primordials;
 
 const {
@@ -30,6 +31,8 @@ const {
   kHandle,
   getCachedHashId,
   getHashCache,
+  getArrayBufferOrView,
+  getBufferSourceBytes,
   getOptionalByteLength,
 } = require('internal/crypto/util');
 
@@ -78,6 +81,17 @@ const emitHmacDigestDeprecation = getDeprecationWarningEmitter(
   'Calling Hmac.digest() more than once is deprecated.',
 );
 
+function normalizeCShakeParameter(value, name) {
+  if (value === undefined) return undefined;
+
+  value = getArrayBufferOrView(value, name);
+  if (TypedArrayPrototypeIncludes(getBufferSourceBytes(value), 0)) {
+    throw new ERR_INVALID_ARG_VALUE(
+      name, value, 'must not contain NUL bytes');
+  }
+  return value;
+}
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -91,10 +105,21 @@ function Hash(algorithm, options) {
     // Coerce -0 to +0.
     xofLen += 0;
   }
+  const functionName = isCopy ? undefined : normalizeCShakeParameter(
+    options?.functionName, 'options.functionName');
+  const customization = isCopy ? undefined : normalizeCShakeParameter(
+    options?.customization, 'options.customization');
   // Lookup the cached ID from JS land because it's faster than decoding
   // the string in C++ land.
   const algorithmId = isCopy ? -1 : getCachedHashId(algorithm);
-  this[kHandle] = new _Hash(algorithm, xofLen, algorithmId, getHashCache());
+  this[kHandle] = new _Hash(
+    algorithm,
+    xofLen,
+    algorithmId,
+    getHashCache(),
+    functionName,
+    customization,
+  );
   this[kState] = {
     [kFinalized]: false,
   };
@@ -279,6 +304,8 @@ function hash(algorithm, input, options) {
   }
   let outputEncoding;
   let outputLength;
+  let functionName;
+  let customization;
 
   if (typeof options === 'string') {
     outputEncoding = options;
@@ -286,6 +313,10 @@ function hash(algorithm, input, options) {
     validateObject(options, 'options');
     outputLength = options.outputLength;
     outputEncoding = options.outputEncoding;
+    functionName = normalizeCShakeParameter(
+      options.functionName, 'options.functionName');
+    customization = normalizeCShakeParameter(
+      options.customization, 'options.customization');
   }
 
   outputEncoding ??= 'hex';
@@ -313,7 +344,8 @@ function hash(algorithm, input, options) {
   }
 
   return oneShotDigest(algorithm, getCachedHashId(algorithm), getHashCache(),
-                       input, normalized, encodingsMap[normalized], outputLength);
+                       input, normalized, encodingsMap[normalized], outputLength,
+                       functionName, customization);
 }
 
 module.exports = {

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -93,21 +93,30 @@ EVP_MD* GetCachedMDByID(Environment* env, size_t id) {
 
 struct MaybeCachedMD {
   EVP_MD* explicit_md = nullptr;
-  const EVP_MD* implicit_md = nullptr;
+  ncrypto::Digest digest;
   int32_t cache_id = -1;
 };
 
 MaybeCachedMD FetchAndMaybeCacheMD(Environment* env, const char* search_name) {
-  const EVP_MD* implicit_md = ncrypto::getDigestByName(search_name);
-  if (!implicit_md) return {nullptr, nullptr, -1};
+  auto cached = env->alias_to_md_id_map.find(search_name);
+  if (cached != env->alias_to_md_id_map.end()) {
+    const size_t id = cached->second;
+    EVP_MD* md = GetCachedMDByID(env, id);
+    return {md, md, static_cast<int32_t>(id)};
+  }
 
-  const char* real_name = EVP_MD_get0_name(implicit_md);
-  if (!real_name) return {nullptr, implicit_md, -1};
+  const ncrypto::Digest digest = ncrypto::Digest::FromName(search_name);
+  if (!digest) return {};
+
+  const char* real_name = EVP_MD_get0_name(digest);
+  if (!real_name) return {nullptr, digest, -1};
 
   auto it = env->alias_to_md_id_map.find(real_name);
   if (it != env->alias_to_md_id_map.end()) {
-    size_t id = it->second;
-    return {GetCachedMDByID(env, id), implicit_md, static_cast<int32_t>(id)};
+    const size_t id = it->second;
+    EVP_MD* md = GetCachedMDByID(env, id);
+    env->alias_to_md_id_map.emplace(search_name, id);
+    return {md, md, static_cast<int32_t>(id)};
   }
 
   // EVP_*_fetch() does not support alias names, so we need to pass it the
@@ -117,7 +126,7 @@ MaybeCachedMD FetchAndMaybeCacheMD(Environment* env, const char* search_name) {
   // algorithms are used internally by OpenSSL and are also passed to this
   // callback).
   EVP_MD* explicit_md = EVP_MD_fetch(nullptr, real_name, nullptr);
-  if (!explicit_md) return {nullptr, implicit_md, -1};
+  if (!explicit_md) return {nullptr, digest, -1};
 
   // Cache the EVP_MD* fetched.
   env->evp_md_cache.emplace_back(explicit_md);
@@ -131,7 +140,7 @@ MaybeCachedMD FetchAndMaybeCacheMD(Environment* env, const char* search_name) {
   }
   env->alias_to_md_id_map.emplace(search_name, id);
 
-  return {explicit_md, implicit_md, static_cast<int32_t>(id)};
+  return {explicit_md, explicit_md, static_cast<int32_t>(id)};
 }
 
 void SaveSupportedHashAlgorithmsAndCacheMD(const EVP_MD* md,
@@ -144,6 +153,54 @@ void SaveSupportedHashAlgorithmsAndCacheMD(const EVP_MD* md,
   if (result.explicit_md) {
     env->supported_hash_algorithms.push_back(from);
   }
+}
+
+struct ProviderHashNameContext {
+  Environment* env;
+  size_t cache_id;
+};
+
+void SaveSupportedProviderHashName(const char* name, void* arg) {
+  if (name == nullptr) return;
+
+  const std::string_view name_view(name);
+  const bool is_dotted_decimal =
+      name_view.find('.') != std::string_view::npos &&
+      std::all_of(name_view.begin(), name_view.end(), [](unsigned char c) {
+        return (c >= '0' && c <= '9') || c == '.';
+      });
+  if (is_dotted_decimal) return;
+
+  std::string normalized_name(name_view);
+  std::transform(normalized_name.begin(),
+                 normalized_name.end(),
+                 normalized_name.begin(),
+                 [](unsigned char c) {
+                   if (c >= 'A' && c <= 'Z') {
+                     return static_cast<char>(c + ('a' - 'A'));
+                   }
+                   return static_cast<char>(c);
+                 });
+
+  auto* context = static_cast<ProviderHashNameContext*>(arg);
+  context->env->supported_hash_algorithms.push_back(normalized_name);
+  context->env->alias_to_md_id_map.emplace(normalized_name, context->cache_id);
+}
+
+void SaveSupportedProviderHashAlgorithms(EVP_MD* md, void* arg) {
+  const char* name = EVP_MD_get0_name(md);
+  if (name == nullptr) return;
+
+  Environment* env = static_cast<Environment*>(arg);
+  auto result = FetchAndMaybeCacheMD(env, name);
+  if (result.explicit_md == nullptr) return;
+
+  ProviderHashNameContext context = {
+      .env = env,
+      .cache_id = static_cast<size_t>(result.cache_id),
+  };
+  EVP_MD_names_do_all(
+      result.explicit_md, SaveSupportedProviderHashName, &context);
 }
 
 #else
@@ -169,6 +226,7 @@ const std::vector<std::string>& GetSupportedHashAlgorithms(Environment* env) {
     // Since we'll fetch the EVP_MD*, cache them along the way to speed up
     // later lookups instead of throwing them away immediately.
     EVP_MD_do_all_sorted(SaveSupportedHashAlgorithmsAndCacheMD, env);
+    EVP_MD_do_all_provided(nullptr, SaveSupportedProviderHashAlgorithms, env);
 #else
     EVP_MD_do_all_sorted(SaveSupportedHashAlgorithms, env);
 #endif
@@ -210,10 +268,10 @@ void Hash::GetCachedAliases(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(result);
 }
 
-const EVP_MD* GetDigestImplementation(Environment* env,
-                                      Local<Value> algorithm,
-                                      Local<Value> cache_id_val,
-                                      Local<Value> algorithm_cache) {
+ncrypto::Digest GetDigestImplementation(Environment* env,
+                                        Local<Value> algorithm,
+                                        Local<Value> cache_id_val,
+                                        Local<Value> algorithm_cache) {
   CHECK(algorithm->IsString());
   CHECK(cache_id_val->IsInt32());
   CHECK(algorithm_cache->IsObject());
@@ -243,10 +301,11 @@ const EVP_MD* GetDigestImplementation(Environment* env,
     }
   }
 
-  return result.explicit_md ? result.explicit_md : result.implicit_md;
+  return result.explicit_md ? ncrypto::Digest(result.explicit_md)
+                            : result.digest;
 #else
   Utf8Value utf8(env->isolate(), algorithm);
-  return ncrypto::getDigestByName(*utf8);
+  return ncrypto::Digest::FromName(*utf8);
 #endif
 }
 
@@ -287,12 +346,12 @@ bool ShouldRejectMissingXofLength(const EVP_MD* md, size_t default_length) {
 #endif
 }
 
-// crypto.digest(algorithm, algorithmId, algorithmCache,
-//               input, outputEncoding, outputEncodingId, outputLength)
+// crypto.digest(algorithm, algorithmId, algorithmCache, input, outputEncoding,
+//               outputEncodingId, outputLength, functionName, customization)
 void Hash::OneShotDigest(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
-  CHECK_EQ(args.Length(), 7);
+  CHECK_EQ(args.Length(), 9);
   CHECK(args[0]->IsString());                                  // algorithm
   CHECK(args[1]->IsInt32());                                   // algorithmId
   CHECK(args[2]->IsObject());                                  // algorithmCache
@@ -301,8 +360,12 @@ void Hash::OneShotDigest(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[5]->IsUint32() || args[5]->IsUndefined());  // outputEncodingId
   CHECK(args[6]->IsUint32() || args[6]->IsUndefined());  // outputLength
 
-  const EVP_MD* md = GetDigestImplementation(env, args[0], args[1], args[2]);
-  if (md == nullptr) [[unlikely]] {
+  CShakeOptions options;
+  if (GetCShakeOptions(args, 7, &options).IsNothing()) return;
+
+  const ncrypto::Digest md =
+      GetDigestImplementation(env, args[0], args[1], args[2]);
+  if (!md) [[unlikely]] {
     Utf8Value method(isolate, args[0]);
     std::string message =
         "Digest method " + method.ToString() + " is not supported";
@@ -335,7 +398,7 @@ void Hash::OneShotDigest(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  if (output_length == 0) {
+  auto return_empty_output = [&]() {
     if (output_enc == BUFFER) {
       Local<Uint8Array> u8;
       if (Buffer::New(isolate, ArrayBuffer::New(isolate, 0), 0, 0)
@@ -345,28 +408,46 @@ void Hash::OneShotDigest(const FunctionCallbackInfo<Value>& args) {
     } else {
       args.GetReturnValue().Set(String::Empty(isolate));
     }
-    return;
+  };
+
+  if (output_length == 0 && options.empty()) {
+    return return_empty_output();
   }
 
-  DataPointer output = ([&]() -> DataPointer {
-    if (args[3]->IsString()) {
-      Utf8Value utf8(isolate, args[3]);
-      ncrypto::Buffer<const unsigned char> buf = {
-          .data = reinterpret_cast<const unsigned char*>(utf8.out()),
-          .len = utf8.length(),
-      };
-      return is_xof ? ncrypto::xofHashDigest(buf, md, output_length)
-                    : ncrypto::hashDigest(buf, md);
-    }
-
-    ArrayBufferViewContents<unsigned char> input(args[3]);
-    ncrypto::Buffer<const unsigned char> buf = {
-        .data = reinterpret_cast<const unsigned char*>(input.data()),
-        .len = input.length(),
+  ncrypto::Buffer<const unsigned char> input;
+  std::optional<Utf8Value> utf8;
+  std::optional<ArrayBufferViewContents<unsigned char>> buffer;
+  if (args[3]->IsString()) {
+    utf8.emplace(isolate, args[3]);
+    input = {
+        .data = reinterpret_cast<const unsigned char*>(utf8->out()),
+        .len = static_cast<size_t>(utf8->length()),
     };
-    return is_xof ? ncrypto::xofHashDigest(buf, md, output_length)
-                  : ncrypto::hashDigest(buf, md);
-  })();
+  } else {
+    buffer.emplace(args[3]);
+    input = {
+        .data = buffer->data(),
+        .len = buffer->length(),
+    };
+  }
+
+  DataPointer output;
+  if (options.empty()) {
+    output = is_xof ? ncrypto::xofHashDigest(input, md, output_length)
+                    : ncrypto::hashDigest(input, md);
+  } else {
+    EVPMDCtxPointer ctx = EVPMDCtxPointer::New();
+    if (!options.Initialize(&ctx, md)) {
+      return ThrowCryptoError(
+          env, ERR_get_error(), "Digest options are not supported");
+    }
+    if (!ctx.digestUpdate(
+            reinterpret_cast<const ncrypto::Buffer<const void>&>(input))) {
+      return ThrowCryptoError(env, ERR_get_error());
+    }
+    if (output_length == 0) return return_empty_output();
+    output = ctx.digestFinal(output_length);
+  }
 
   if (!output) [[unlikely]] {
     return ThrowCryptoError(env, ERR_get_error());
@@ -418,9 +499,11 @@ void Hash::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 #endif
 }
 
-// new Hash(algorithm, algorithmId, xofLen, algorithmCache)
+// new Hash(algorithm, xofLen, algorithmId, algorithmCache, functionName,
+//          customization)
 void Hash::New(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  CHECK_EQ(args.Length(), 6);
 
   Maybe<unsigned int> xof_md_len = Nothing<unsigned int>();
   if (!args[1]->IsUndefined()) {
@@ -429,19 +512,23 @@ void Hash::New(const FunctionCallbackInfo<Value>& args) {
   }
 
   const Hash* orig = nullptr;
-  const EVP_MD* md = nullptr;
+  ncrypto::Digest md;
   if (args[0]->IsObject()) {
     ASSIGN_OR_RETURN_UNWRAP(&orig, args[0].As<Object>());
     CHECK_NOT_NULL(orig);
     md = orig->mdctx_.getDigest();
   } else {
-    md = GetDigestImplementation(env, args[0], args[2], args[3]);
+    const ncrypto::Digest resolved =
+        GetDigestImplementation(env, args[0], args[2], args[3]);
+    md = resolved;
   }
 
   Hash* hash = new Hash(env, args.This());
-  if (md == nullptr || !hash->HashInit(md, xof_md_len)) {
-    return ThrowCryptoError(env, ERR_get_error(),
-                            "Digest method not supported");
+  CShakeOptions options;
+  if (GetCShakeOptions(args, 4, &options).IsNothing()) return;
+  if (!md || !hash->HashInit(md, options, xof_md_len)) {
+    return ThrowCryptoError(
+        env, ERR_get_error(), "Digest method not supported");
   }
 
   if (orig != nullptr && !orig->mdctx_.copyTo(hash->mdctx_)) {
@@ -449,17 +536,18 @@ void Hash::New(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-bool Hash::HashInit(const EVP_MD* md, Maybe<unsigned int> xof_md_len) {
+bool Hash::HashInit(const ncrypto::Digest& digest,
+                    const CShakeOptions& options,
+                    Maybe<unsigned int> xof_md_len) {
   mdctx_ = EVPMDCtxPointer::New();
-  if (!mdctx_.digestInit(md)) [[unlikely]] {
+  if (!options.Initialize(&mdctx_, digest)) [[unlikely]] {
     mdctx_.reset();
     return false;
   }
 
   md_len_ = mdctx_.getDigestSize();
-
   if (mdctx_.hasXofFlag() && !xof_md_len.IsJust() &&
-      ShouldRejectMissingXofLength(md, md_len_)) {
+      ShouldRejectMissingXofLength(digest, md_len_)) {
     MarkInvalidXofLength();
     mdctx_.reset();
     return false;
@@ -543,7 +631,10 @@ void Hash::HashDigest(const FunctionCallbackInfo<Value>& args) {
 }
 
 HashConfig::HashConfig(HashConfig&& other) noexcept
-    : in(std::move(other.in)), digest(other.digest), length(other.length) {}
+    : in(std::move(other.in)),
+      digest(other.digest),
+      options(std::move(other.options)),
+      length(other.length) {}
 
 HashConfig& HashConfig::operator=(HashConfig&& other) noexcept {
   if (&other == this) return *this;
@@ -553,6 +644,7 @@ HashConfig& HashConfig::operator=(HashConfig&& other) noexcept {
 
 void HashConfig::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TraitTrackInline(in, "in");
+  tracker->TrackField("options", options);
 }
 
 MaybeLocal<Value> HashTraits::EncodeOutput(Environment* env,
@@ -570,8 +662,8 @@ Maybe<void> HashTraits::AdditionalConfig(
 
   CHECK(args[offset]->IsString());  // Hash algorithm
   Utf8Value digest(env->isolate(), args[offset]);
-  params->digest = ncrypto::getDigestByName(*digest);
-  if (params->digest == nullptr) [[unlikely]] {
+  params->digest = ncrypto::Digest::FromName(*digest);
+  if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
     return Nothing<void>();
   }
@@ -583,7 +675,11 @@ Maybe<void> HashTraits::AdditionalConfig(
   }
   params->in = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
-  unsigned int expected = EVP_MD_size(params->digest);
+  if (GetCShakeOptions(args, offset + 3, &params->options).IsNothing()) {
+    return Nothing<void>();
+  }
+
+  unsigned int expected = EVP_MD_size(params->digest.get());
   params->length = expected;
   if (args[offset + 2]->IsUint32()) [[unlikely]] {
     // length is expressed in terms of bits
@@ -591,7 +687,8 @@ Maybe<void> HashTraits::AdditionalConfig(
         static_cast<uint32_t>(args[offset + 2].As<Uint32>()->Value()) /
         CHAR_BIT;
     if (params->length != expected) {
-      if ((EVP_MD_flags(params->digest) & EVP_MD_FLAG_XOF) == 0) [[unlikely]] {
+      if ((EVP_MD_flags(params->digest.get()) & EVP_MD_FLAG_XOF) == 0)
+          [[unlikely]] {
         THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Digest method not supported");
         return Nothing<void>();
       }
@@ -608,8 +705,8 @@ bool HashTraits::DeriveBits(Environment* env,
                             CryptoErrorStore* errors) {
   auto ctx = EVPMDCtxPointer::New();
 
-  if (!ctx.digestInit(params.digest) || !ctx.digestUpdate(params.in))
-      [[unlikely]] {
+  if (!params.options.Initialize(&ctx, params.digest) ||
+      !ctx.digestUpdate(params.in)) [[unlikely]] {
     return false;
   }
 

--- a/src/crypto/crypto_hash.h
+++ b/src/crypto/crypto_hash.h
@@ -21,7 +21,9 @@ class Hash final : public BaseObject {
   SET_MEMORY_INFO_NAME(Hash)
   SET_SELF_SIZE(Hash)
 
-  bool HashInit(const EVP_MD* md, v8::Maybe<unsigned int> xof_md_len);
+  bool HashInit(const ncrypto::Digest& digest,
+                const CShakeOptions& options,
+                v8::Maybe<unsigned int> xof_md_len);
   bool HashUpdate(const char* data, size_t len);
 
   static void GetHashes(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -43,7 +45,8 @@ class Hash final : public BaseObject {
 
 struct HashConfig final : public MemoryRetainer {
   ByteSource in;
-  const EVP_MD* digest;
+  ncrypto::Digest digest;
+  CShakeOptions options;
   unsigned int length;
 
   HashConfig() = default;

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -38,6 +38,21 @@ using v8::Uint32;
 using v8::Value;
 
 namespace crypto {
+namespace {
+bool IsRsaPssDigestEncodable(const Digest& digest) {
+#if NCRYPTO_USE_OPENSSL3_PROVIDER
+  const int nid = EVP_MD_type(digest.get());
+  if (nid == NID_undef) return false;
+
+  const ASN1_OBJECT* object = OBJ_nid2obj(nid);
+  return object != nullptr && OBJ_length(object) > 0;
+#else
+  static_cast<void>(digest);
+  return true;
+#endif
+}
+}  // namespace
+
 EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
   auto ctx = EVPKeyCtxPointer::NewFromID(
       params->params.variant == kKeyVariantRSA_PSS ? EVP_PKEY_RSA_PSS
@@ -58,7 +73,8 @@ EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
   }
 
   if (params->params.variant == kKeyVariantRSA_PSS) {
-    if (params->params.md && !ctx.setRsaPssKeygenMd(params->params.md)) {
+    if (params->params.md && (!IsRsaPssDigestEncodable(params->params.md) ||
+                              !ctx.setRsaPssKeygenMd(params->params.md))) {
       return {};
     }
 
@@ -71,7 +87,8 @@ EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
       mgf1_md = params->params.md;
     }
 
-    if (mgf1_md && !ctx.setRsaPssKeygenMgf1Md(mgf1_md)) {
+    if (mgf1_md && (!IsRsaPssDigestEncodable(mgf1_md) ||
+                    !ctx.setRsaPssKeygenMgf1Md(mgf1_md))) {
       return {};
     }
 

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -18,6 +18,11 @@
 #include "openssl/provider.h"
 #endif
 
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_PREREQ(4, 0)
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#endif
+
 namespace node {
 
 using ncrypto::BignumPointer;
@@ -75,6 +80,108 @@ size_t MemoryRetainerTraits<crypto::ByteSource>::SelfSize(
 }
 
 namespace crypto {
+
+CShakeOptions::CShakeOptions(CShakeOptions&& other) noexcept
+    : function_name(std::move(other.function_name)),
+      customization(std::move(other.customization)),
+      flags(other.flags) {}
+
+CShakeOptions& CShakeOptions::operator=(CShakeOptions&& other) noexcept {
+  if (&other == this) return *this;
+  this->~CShakeOptions();
+  return *new (this) CShakeOptions(std::move(other));
+}
+
+void CShakeOptions::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackFieldWithSize("function_name", function_name.size());
+  tracker->TrackFieldWithSize("customization", customization.size());
+}
+
+bool CShakeOptions::Initialize(ncrypto::EVPMDCtxPointer* ctx,
+                               const ncrypto::Digest& digest) const {
+  if (!ctx || !*ctx || !digest) return false;
+  if (empty()) return ctx->digestInit(digest);
+
+#if !defined(OPENSSL_IS_BORINGSSL) && OPENSSL_VERSION_PREREQ(4, 0)
+  const bool is_cshake = EVP_MD_is_a(digest.get(), "CSHAKE-128") ||
+                         EVP_MD_is_a(digest.get(), "CSHAKE-256");
+  if (!is_cshake) return false;
+
+  OSSL_PARAM params[3];
+  size_t count = 0;
+  if (has(kFunctionName)) {
+    params[count++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_DIGEST_PARAM_FUNCTION_NAME,
+        const_cast<char*>(function_name.c_str()),
+        function_name.size());
+  }
+  if (has(kCustomization)) {
+    params[count++] = OSSL_PARAM_construct_utf8_string(
+        OSSL_DIGEST_PARAM_CUSTOMIZATION,
+        const_cast<char*>(customization.c_str()),
+        customization.size());
+  }
+  params[count] = OSSL_PARAM_construct_end();
+  return ctx->digestInit(digest, params);
+#else
+  return false;
+#endif
+}
+
+namespace {
+bool ContainsNullByte(std::string_view value) {
+  return value.find('\0') != std::string_view::npos;
+}
+
+v8::Maybe<void> GetDigestStringOption(
+    Environment* env,
+    const v8::FunctionCallbackInfo<v8::Value>& args,
+    unsigned int offset,
+    CShakeOptions::Flag flag,
+    std::string* target,
+    CShakeOptions* options) {
+  if (args[offset]->IsUndefined()) return v8::JustVoid();
+  CHECK(IsAnyBufferSource(args[offset]));
+  ArrayBufferOrViewContents<char> value(args[offset]);
+  if (!value.CheckSizeInt32()) {
+    THROW_ERR_OUT_OF_RANGE(env, "digest option is too big");
+    return v8::Nothing<void>();
+  }
+  target->assign(value.data(), value.size());
+  if (ContainsNullByte(*target)) {
+    THROW_ERR_INVALID_ARG_VALUE(env,
+                                "Digest options must not contain null bytes");
+    return v8::Nothing<void>();
+  }
+  options->flags |= flag;
+  return v8::JustVoid();
+}
+}  // namespace
+
+v8::Maybe<void> GetCShakeOptions(
+    const v8::FunctionCallbackInfo<v8::Value>& args,
+    unsigned int offset,
+    CShakeOptions* options) {
+  Environment* env = Environment::GetCurrent(args);
+  if (GetDigestStringOption(env,
+                            args,
+                            offset,
+                            CShakeOptions::kFunctionName,
+                            &options->function_name,
+                            options)
+          .IsNothing() ||
+      GetDigestStringOption(env,
+                            args,
+                            offset + 1,
+                            CShakeOptions::kCustomization,
+                            &options->customization,
+                            options)
+          .IsNothing()) {
+    return v8::Nothing<void>();
+  }
+
+  return v8::JustVoid();
+}
 
 int PasswordCallback(char* buf, int size, int rwflag, void* u) {
   const ByteSource* passphrase = *static_cast<const ByteSource**>(u);

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -286,6 +286,36 @@ enum CryptoJobMode { kCryptoJobAsync, kCryptoJobSync, kCryptoJobWebCrypto };
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args);
 bool IsCryptoJobAsync(CryptoJobMode mode);
 
+struct CShakeOptions final : public MemoryRetainer {
+  enum Flag : uint8_t {
+    kFunctionName = 1 << 0,
+    kCustomization = 1 << 1,
+  };
+
+  std::string function_name;
+  std::string customization;
+  uint8_t flags = 0;
+
+  CShakeOptions() = default;
+  CShakeOptions(CShakeOptions&& other) noexcept;
+  CShakeOptions& operator=(CShakeOptions&& other) noexcept;
+
+  bool empty() const { return flags == 0; }
+  bool has(Flag flag) const { return (flags & flag) != 0; }
+
+  bool Initialize(ncrypto::EVPMDCtxPointer* ctx,
+                  const ncrypto::Digest& digest) const;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(CShakeOptions)
+  SET_SELF_SIZE(CShakeOptions)
+};
+
+v8::Maybe<void> GetCShakeOptions(
+    const v8::FunctionCallbackInfo<v8::Value>& args,
+    unsigned int offset,
+    CShakeOptions* options);
+
 v8::MaybeLocal<v8::Value> CreateWebCryptoJobError(Environment* env,
                                                   v8::Local<v8::Value> cause);
 

--- a/test/addons/addons.status
+++ b/test/addons/addons.status
@@ -14,6 +14,7 @@ openssl-binding/test: PASS,FLAKY
 openssl-binding/test: SKIP
 openssl-get-ssl-ctx/test: SKIP
 openssl-providers/test-default-only-config: SKIP
+openssl-providers/test-default-properties-config: SKIP
 openssl-providers/test-legacy-provider-config: SKIP
 openssl-providers/test-legacy-provider-inactive-config: SKIP
 openssl-providers/test-legacy-provider-option: SKIP

--- a/test/addons/openssl-providers/providers.cjs
+++ b/test/addons/openssl-providers/providers.cjs
@@ -21,7 +21,7 @@ const { getProviders } = require(`./build/${common.buildType}/binding`);
 const providers = {
   'default': {
     ciphers: ['des3-wrap'],
-    hashes: ['sha512-256'],
+    hashes: ['keccak-kmac-128', 'keccak-kmac128', 'sha512-256'],
   },
   'legacy': {
     ciphers: ['blowfish', 'idea'],
@@ -47,6 +47,15 @@ function assertArrayIncludes(array, item, desc) {
          `${desc} [${array}] does not include "${item}"`);
 }
 
+function createSupportedHash(hash) {
+  try {
+    return createHash(hash);
+  } catch (err) {
+    if (err?.code !== 'ERR_OSSL_EVP_NOT_XOF_OR_INVALID_LENGTH') throw err;
+    return createHash(hash, { outputLength: 32 });
+  }
+}
+
 function testProviderPresent(provider) {
   debug(`Checking '${provider}' is present`);
   assertArrayIncludes(getProviders(), provider, 'Loaded providers');
@@ -57,7 +66,7 @@ function testProviderPresent(provider) {
   for (const hash of providers[provider].hashes || []) {
     debug(`Checking '${hash}' hash is available`);
     assertArrayIncludes(getHashes(), hash, 'Available hashes');
-    createHash(hash);
+    createSupportedHash(hash);
   }
 }
 

--- a/test/addons/openssl-providers/test-default-properties-config.js
+++ b/test/addons/openssl-providers/test-default-properties-config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../../common');
+const fixtures = require('../../common/fixtures');
+const providers = require('./providers.cjs');
+
+const assert = require('node:assert');
+const { fork } = require('node:child_process');
+const { createHash, getHashes } = require('node:crypto');
+const option = `--openssl-config=${fixtures.path(
+  'openssl3-conf',
+  'default_properties.cnf',
+)}`;
+
+if (!process.execArgv.includes(option)) {
+  const cp = fork(__filename, { execArgv: [option] });
+  cp.on('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+  }));
+  return;
+}
+
+assert(providers.getCurrentProviders().includes('default'));
+assert(providers.getCurrentProviders().includes('legacy'));
+providers.testProviderPresent('default');
+
+const hashes = getHashes();
+for (const hash of ['md4', 'whirlpool']) {
+  assert(!hashes.includes(hash));
+  assert.throws(() => createHash(hash), { code: 'ERR_OSSL_EVP_UNSUPPORTED' });
+}

--- a/test/fixtures/openssl3-conf/default_properties.cnf
+++ b/test/fixtures/openssl3-conf/default_properties.cnf
@@ -1,0 +1,19 @@
+nodejs_conf = nodejs_init
+
+[nodejs_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+# Load both providers but select only implementations from the default provider.
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = provider=default

--- a/test/parallel/test-crypto-provider-hash-options.js
+++ b/test/parallel/test-crypto-provider-hash-options.js
@@ -1,0 +1,257 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+if (Number(process.versions.openssl.split('.')[0]) < 4 ||
+    process.features.openssl_is_boringssl) {
+  common.skip('OpenSSL 4 provider support is required');
+}
+
+const assert = require('node:assert');
+const {
+  createHash,
+  getHashes,
+  hash,
+} = require('node:crypto');
+const { internalBinding } = require('internal/test/binding');
+const {
+  HashJob,
+  kCryptoJobSync,
+  kCryptoJobWebCrypto,
+} = internalBinding('crypto');
+
+const hashes = getHashes();
+const hashNames = new Map(
+  hashes.map((name) => [name.toLowerCase(), name]),
+);
+
+let exercised = false;
+
+function findHash(...names) {
+  for (const name of names) {
+    const result = hashNames.get(name);
+    if (result !== undefined) return result;
+  }
+  return undefined;
+}
+
+function testHashJob(args, expected) {
+  const { 0: err, 1: result } = new HashJob(
+    kCryptoJobSync,
+    ...args,
+  ).run();
+  assert.strictEqual(err, undefined);
+  assert.deepStrictEqual(Buffer.from(result), expected);
+
+  (async () => {
+    const asyncResult = await new HashJob(
+      kCryptoJobWebCrypto,
+      ...args,
+    ).run();
+    assert.deepStrictEqual(Buffer.from(asyncResult), expected);
+  })().then(common.mustCall());
+}
+
+const cshakeVectors = [
+  {
+    names: ['cshake-128', 'cshake128'],
+    shakeNames: ['shake128', 'shake-128'],
+    outputLength: 32,
+    input: Buffer.from('00010203', 'hex'),
+    expected: 'c1c36925b6409a04f1b504fcbca9d82b' +
+              '4017277cb5ed2b2065fc1d3814d5aaf5',
+  },
+  {
+    names: ['cshake-256', 'cshake256'],
+    shakeNames: ['shake256', 'shake-256'],
+    outputLength: 64,
+    input: Buffer.from('00010203', 'hex'),
+    expected: 'd008828e2b80ac9d2218ffee1d070c48' +
+              'b8e4c87bff32c9699d5b6896eee0edd1' +
+              '64020e2be0560858d9c00c037e34a96' +
+              '937c561a74c412bb4c746469527281c8c',
+  },
+];
+
+for (const vector of cshakeVectors) {
+  const algorithm = findHash(...vector.names);
+  if (algorithm === undefined) {
+    common.printSkipMessage(`${vector.names[0]} is not available`);
+    continue;
+  }
+
+  exercised = true;
+
+  const options = {
+    outputLength: vector.outputLength,
+    customization: 'Email Signature',
+  };
+  const streaming = createHash(algorithm, options)
+    .update(vector.input.subarray(0, 2))
+    .update(vector.input.subarray(2))
+    .digest('hex');
+  const partial = createHash(algorithm, options)
+    .update(vector.input.subarray(0, 2));
+  const copied = partial.copy({ outputLength: vector.outputLength })
+    .update(vector.input.subarray(2))
+    .digest('hex');
+
+  assert.strictEqual(streaming, vector.expected);
+  assert.strictEqual(copied, vector.expected);
+  assert.strictEqual(hash(algorithm, vector.input, options), vector.expected);
+
+  // BufferSource parameters have the same semantics as their string form.
+  const bufferOptions = {
+    ...options,
+    customization: Buffer.from(options.customization),
+  };
+  assert.strictEqual(
+    createHash(algorithm, bufferOptions).update(vector.input).digest('hex'),
+    vector.expected,
+  );
+  assert.strictEqual(
+    hash(algorithm, vector.input, bufferOptions),
+    vector.expected,
+  );
+
+  // With empty function-name and customization parameters, cSHAKE is SHAKE.
+  const withoutParameters = createHash(algorithm)
+    .update(vector.input)
+    .digest('hex');
+  assert.strictEqual(hash(algorithm, vector.input), withoutParameters);
+
+  const shake = findHash(...vector.shakeNames);
+  if (shake !== undefined) {
+    assert.strictEqual(
+      withoutParameters,
+      createHash(shake, { outputLength: vector.outputLength })
+        .update(vector.input)
+        .digest('hex'),
+    );
+  }
+
+  const namedOptions = {
+    outputLength: vector.outputLength,
+    functionName: 'KMAC',
+    customization: 'Node.js',
+  };
+  let namedResult;
+  try {
+    namedResult = createHash(algorithm, namedOptions)
+      .update(vector.input)
+      .digest();
+  } catch {
+    common.printSkipMessage(
+      `${algorithm} does not support the KMAC function name`,
+    );
+  }
+  if (namedResult !== undefined) {
+    assert.deepStrictEqual(
+      hash(algorithm, vector.input, {
+        ...namedOptions,
+        outputEncoding: 'buffer',
+      }),
+      namedResult,
+    );
+    assert.deepStrictEqual(
+      createHash(algorithm, {
+        ...namedOptions,
+        functionName: Buffer.from(namedOptions.functionName),
+        customization: new Uint8Array(Buffer.from(namedOptions.customization)),
+      }).update(vector.input).digest(),
+      namedResult,
+    );
+    assert.deepStrictEqual(
+      hash(algorithm, vector.input, {
+        ...namedOptions,
+        functionName: Buffer.from(namedOptions.functionName),
+        customization: new Uint8Array(Buffer.from(namedOptions.customization)),
+        outputEncoding: 'buffer',
+      }),
+      namedResult,
+    );
+  }
+
+  for (const functionName of ['', 'TupleHash', 'ParallelHash', 'KMAC']) {
+    const functionOptions = {
+      outputLength: vector.outputLength,
+      functionName,
+    };
+    let functionResult;
+    try {
+      functionResult = createHash(algorithm, functionOptions)
+        .update(vector.input)
+        .digest();
+    } catch {
+      common.printSkipMessage(
+        `${algorithm} does not support the ${functionName} function name`,
+      );
+      continue;
+    }
+    assert.deepStrictEqual(
+      functionResult,
+      hash(algorithm, vector.input, {
+        ...functionOptions,
+        outputEncoding: 'buffer',
+      }),
+    );
+  }
+
+  testHashJob([
+    algorithm,
+    vector.input,
+    vector.outputLength * 8,
+    undefined,
+    Buffer.from(options.customization),
+  ], Buffer.from(vector.expected, 'hex'));
+
+  for (const invalidOptions of [
+    { functionName: 1 },
+    { customization: {} },
+  ]) {
+    const expected = { code: 'ERR_INVALID_ARG_TYPE' };
+    assert.throws(() => createHash(algorithm, invalidOptions), expected);
+    assert.throws(
+      () => hash(algorithm, vector.input, invalidOptions),
+      expected,
+    );
+  }
+
+  for (const invalidOptions of [
+    { functionName: 'KMAC\0' },
+    { customization: 'Node\0js' },
+    { customization: Buffer.from([0x61, 0x00, 0x62]) },
+  ]) {
+    const expected = { code: 'ERR_INVALID_ARG_VALUE' };
+    assert.throws(() => createHash(algorithm, invalidOptions), expected);
+    assert.throws(
+      () => hash(algorithm, vector.input, invalidOptions),
+      expected,
+    );
+  }
+}
+
+if (cshakeVectors.some(({ names }) => findHash(...names) !== undefined)) {
+  for (const mismatchedOptions of [
+    { functionName: 'KMAC' },
+    { customization: 'Node.js' },
+  ]) {
+    assert.throws(
+      () => createHash('sha256', mismatchedOptions),
+      { message: 'Digest method not supported' },
+    );
+    assert.throws(
+      () => hash('sha256', Buffer.from('abc'), mismatchedOptions),
+      { message: 'Digest options are not supported' },
+    );
+  }
+}
+
+if (!exercised) {
+  common.printSkipMessage('cSHAKE is not available');
+}

--- a/test/parallel/test-crypto-provider-hashes.js
+++ b/test/parallel/test-crypto-provider-hashes.js
@@ -1,0 +1,253 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const assert = require('node:assert');
+const {
+  createHash,
+  createHmac,
+  createSign,
+  createVerify,
+  generateKeyPair,
+  generateKeyPairSync,
+  getHashes,
+  hash,
+  hkdf,
+  hkdfSync,
+  pbkdf2,
+  pbkdf2Sync,
+  privateDecrypt,
+  publicEncrypt,
+  sign,
+  verify,
+} = require('node:crypto');
+const { hasOpenSSL3 } = require('../common/crypto');
+
+if (!hasOpenSSL3 || process.features.openssl_is_boringssl) {
+  common.skip('OpenSSL 3 provider support is required');
+}
+
+const { internalBinding } = require('internal/test/binding');
+const {
+  HashJob,
+  kCryptoJobSync,
+  kCryptoJobWebCrypto,
+} = internalBinding('crypto');
+
+const hashes = getHashes();
+const lowercaseHashes = hashes.map((name) => name.toLowerCase());
+
+assert.deepStrictEqual(hashes, [...hashes].sort());
+assert.strictEqual(new Set(lowercaseHashes).size, hashes.length);
+if (lowercaseHashes.includes('sha1')) {
+  assert(hashes.includes('RSA-SHA1'));
+}
+assert(!lowercaseHashes.includes('null'));
+assert(!lowercaseHashes.includes('ml-dsa-mu'));
+assert(!hashes.some((name) => /^\d+(?:\.\d+)+$/.test(name)));
+
+for (const name of hashes) {
+  try {
+    createHash(name);
+  } catch (err) {
+    assert.strictEqual(err.code, 'ERR_OSSL_EVP_NOT_XOF_OR_INVALID_LENGTH');
+    createHash(name, { outputLength: 32 });
+  }
+}
+
+const input = Buffer.alloc(0);
+assert.throws(
+  () => createHash('ml-dsa-mu'),
+  /Digest method not supported/,
+);
+assert.throws(
+  () => hash('ml-dsa-mu', input),
+  { message: 'Digest method ml-dsa-mu is not supported' },
+);
+
+const providerVectors = {
+  'keccak-kmac-128': {
+    aliases: ['keccak-kmac-128', 'keccak-kmac128'],
+    expected: '83aa04c211dc19d16912571ed0a75130' +
+              'd36aebd58562dd080c1ea84a8c7d73f7',
+    options: { outputLength: 32 },
+  },
+  'keccak-256': {
+    aliases: ['keccak-256'],
+    expected: 'c5d2460186f7233c927e7db2dcc703c0' +
+              'e500b653ca82273b7bfad8045d85a470',
+  },
+  'sha256-192': {
+    aliases: ['sha2-256/192', 'sha-256/192', 'sha256-192'],
+    expected: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934c',
+  },
+};
+
+function testHashVector({ aliases, expected, options }) {
+  for (const alias of aliases) {
+    if (!hashes.includes(alias)) continue;
+    assert(!hashes.includes(alias.toUpperCase()));
+
+    const streaming = createHash(alias, options).update(input).digest('hex');
+    assert.strictEqual(streaming, expected);
+    assert.strictEqual(hash(alias, input, options), expected);
+  }
+}
+
+// These digests are tested when the active provider advertises them.
+for (const name of ['keccak-kmac-128', 'keccak-256', 'sha256-192']) {
+  const vector = providerVectors[name];
+  if (vector.aliases.some((alias) => hashes.includes(alias))) {
+    testHashVector(vector);
+  } else {
+    common.printSkipMessage(`${name} is not available from the active provider`);
+  }
+}
+
+const keccakKmacName = providerVectors['keccak-kmac-128'].aliases
+  .find((alias) => hashes.includes(alias));
+if (keccakKmacName !== undefined) {
+  (async () => {
+    const { expected } = providerVectors['keccak-kmac-128'];
+    const { 0: err, 1: syncResult } = new HashJob(
+      kCryptoJobSync,
+      keccakKmacName,
+      input,
+      256,
+    ).run();
+    assert.strictEqual(err, undefined);
+    assert.strictEqual(Buffer.from(syncResult).toString('hex'), expected);
+
+    const result = await new HashJob(
+      kCryptoJobWebCrypto,
+      keccakKmacName,
+      input,
+      256,
+    ).run();
+    assert.strictEqual(Buffer.from(result).toString('hex'), expected);
+  })().then(common.mustCall());
+}
+
+if (hashes.includes('sha256-192')) {
+  const operationInput = Buffer.from('abc');
+
+  assert.strictEqual(
+    createHmac('sha256-192', 'key').update(operationInput).digest('hex'),
+    'd7774e586190fa2d2f4d4be4bc86ccd459a9170d52c38809',
+  );
+
+  const hkdfExpected = 'ef23757b94b5e1e46c3f981d87828d7aeb0207733ab5c78' +
+                       'c60df321c9e8c88e0ad54b4eecfef8c258ccd';
+  assert.strictEqual(
+    Buffer.from(hkdfSync('sha256-192', 'key', 'salt', 'info', 42))
+      .toString('hex'),
+    hkdfExpected,
+  );
+  hkdf(
+    'sha256-192',
+    'key',
+    'salt',
+    'info',
+    42,
+    common.mustSucceed((result) => {
+      assert.strictEqual(Buffer.from(result).toString('hex'), hkdfExpected);
+    }),
+  );
+
+  const pbkdf2Expected = '1fee3dd5ea13d5b563d3cc88fbc6dcf7' +
+                         '3497aeffc3b3e6358ab3d3d1aa2aa0ee';
+  assert.strictEqual(
+    pbkdf2Sync('password', 'salt', 2, 32, 'sha256-192').toString('hex'),
+    pbkdf2Expected,
+  );
+  pbkdf2(
+    'password',
+    'salt',
+    2,
+    32,
+    'sha256-192',
+    common.mustSucceed((result) => {
+      assert.strictEqual(result.toString('hex'), pbkdf2Expected);
+    }),
+  );
+
+  const { privateKey: ecPrivateKey, publicKey: ecPublicKey } =
+    generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const signature = sign('sha256-192', operationInput, ecPrivateKey);
+  assert(verify('sha256-192', operationInput, ecPublicKey, signature));
+
+  const streamingSignature = createSign('sha256-192')
+    .update(operationInput)
+    .sign(ecPrivateKey);
+  const verifier = createVerify('sha256-192');
+  verifier.update(operationInput);
+  assert(verifier.verify(ecPublicKey, streamingSignature));
+
+  sign(
+    'sha256-192',
+    operationInput,
+    ecPrivateKey,
+    common.mustSucceed((asyncSignature) => {
+      verify(
+        'sha256-192',
+        operationInput,
+        ecPublicKey,
+        asyncSignature,
+        common.mustSucceed((result) => assert(result)),
+      );
+    }),
+  );
+
+  const { privateKey: rsaPrivateKey, publicKey: rsaPublicKey } =
+    generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const plaintext = Buffer.from('provider digest');
+
+  assert.throws(
+    () => sign('sha256-192', plaintext, rsaPrivateKey),
+    { code: 'ERR_OSSL_DIGEST_NOT_ALLOWED' },
+  );
+  assert.deepStrictEqual(
+    privateDecrypt(
+      { key: rsaPrivateKey, oaepHash: 'sha256-192' },
+      publicEncrypt(
+        { key: rsaPublicKey, oaepHash: 'sha256-192' },
+        plaintext,
+      ),
+    ),
+    plaintext,
+  );
+
+  const pssOptions = [
+    {
+      hashAlgorithm: 'sha256-192',
+      modulusLength: 2048,
+    },
+    {
+      hashAlgorithm: 'sha256',
+      mgf1HashAlgorithm: 'sha256-192',
+      modulusLength: 2048,
+    },
+  ];
+  const keyGenerationFailed = { message: 'Key generation job failed' };
+
+  for (const options of pssOptions) {
+    assert.throws(
+      () => generateKeyPairSync('rsa-pss', options),
+      keyGenerationFailed,
+    );
+    generateKeyPair(
+      'rsa-pss',
+      options,
+      common.mustCall((err, publicKey, privateKey) => {
+        assert.strictEqual(err?.message, keyGenerationFailed.message);
+        assert.strictEqual(publicKey, undefined);
+        assert.strictEqual(privateKey, undefined);
+      }),
+    );
+  }
+}

--- a/typings/internalBinding/crypto.d.ts
+++ b/typings/internalBinding/crypto.d.ts
@@ -1,6 +1,8 @@
 declare namespace InternalCryptoBinding {
   type Buffer = Uint8Array;
-  type ByteSource = string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView;
+  type BufferSource = ArrayBuffer | SharedArrayBuffer | ArrayBufferView;
+  type OptionalBufferSource = BufferSource | undefined;
+  type ByteSource = string | BufferSource;
   type OptionalByteSource = ByteSource | undefined;
   type JwkKey = Record<string, string | string[] | boolean | undefined>;
   type KeyFormatDER = 0;
@@ -300,6 +302,8 @@ declare namespace InternalCryptoBinding {
       algorithm: string,
       data: ByteSource,
       outputLength?: number,
+      functionName?: OptionalBufferSource,
+      customization?: OptionalBufferSource,
     ): CryptoJobForMode<M, ArrayBuffer>;
   }
 
@@ -818,6 +822,8 @@ export interface CryptoBinding {
     xofLen?: number,
     algorithmId?: number,
     algorithmCache?: Record<string, number>,
+    functionName?: InternalCryptoBinding.OptionalBufferSource,
+    customization?: InternalCryptoBinding.OptionalBufferSource,
   ) => InternalCryptoBinding.HashHandle;
   Hmac: new () => InternalCryptoBinding.HmacHandle;
   KeyObjectHandle: new () => InternalCryptoBinding.KeyObjectHandle;
@@ -953,6 +959,8 @@ export interface CryptoBinding {
     outputEncoding: string,
     outputEncodingId?: number,
     outputLength?: number,
+    functionName?: InternalCryptoBinding.OptionalBufferSource,
+    customization?: InternalCryptoBinding.OptionalBufferSource,
   ): string | InternalCryptoBinding.Buffer;
   parseX509(data: InternalCryptoBinding.ByteSource): InternalCryptoBinding.X509CertificateHandle;
   privateDecrypt: InternalCryptoBinding.PublicKeyCipher;


### PR DESCRIPTION
Enumerate digests and aliases from activated OpenSSL 3 providers instead of relying only on OpenSSL's legacy digest registry. Normalize provider aliases and omit numeric OIDs and NULL. Re-fetch each implementation using the active default property query, preserve legacy names, and retain the OpenSSL 1.1.1 and BoringSSL fallbacks.

Resolve provider-only digest names across hash, HMAC, KDF, signature, and RSA digest paths. Teach ncrypto::Digest to own fetched EVP_MD implementations with up-ref copy semantics, and retain that ownership in asynchronous hash jobs.

This exposes provider digests such as KECCAK-KMAC-128, KECCAK-256, and SHA256-192. Add `functionName` and `customization` options to `createHash()` and `crypto.hash()` for cSHAKE digests on OpenSSL 4.

Document provider-dependent availability and operation-specific digest restrictions. Add known-answer vectors, alias normalization, property-query coverage, cSHAKE option validation, and cross-API tests.